### PR TITLE
Allow negative conditional binding ?!=

### DIFF
--- a/src/NodeBind.js
+++ b/src/NodeBind.js
@@ -115,9 +115,16 @@
     return this.bindings.textContent = value;
   }
 
-  function updateAttribute(el, name, conditional, value) {
+  function updateAttribute(el, name, conditional, negativeConditional, value) {
     if (conditional) {
       if (value)
+        el.setAttribute(name, '');
+      else
+        el.removeAttribute(name);
+      return;
+    }
+    if (negativeConditional) {
+      if (!value)
         el.setAttribute(name, '');
       else
         el.removeAttribute(name);
@@ -127,9 +134,9 @@
     el.setAttribute(name, sanitizeValue(value));
   }
 
-  function attributeBinding(el, name, conditional) {
+  function attributeBinding(el, name, conditional, negativeConditional) {
     return function(value) {
-      updateAttribute(el, name, conditional, value);
+      updateAttribute(el, name, conditional, negativeConditional,value);
     };
   }
 
@@ -140,12 +147,18 @@
       name = name.slice(0, -1);
     }
 
+    var negativeConditional = name.substr(-2) == '?!';
+    if (negativeConditional) {
+        this.removeAttribute(name);
+        name = name.slice(0, -2);
+    }
+
     if (oneTime)
-      return updateAttribute(this, name, conditional, value);
+      return updateAttribute(this, name, conditional, negativeConditional, value);
 
     unbind(this, name);
-    updateAttribute(this, name, conditional,
-        value.open(attributeBinding(this, name, conditional)));
+    updateAttribute(this, name, conditional, negativeConditional,
+        value.open(attributeBinding(this, name, conditional, negativeConditional)));
 
     return this.bindings[name] = value;
   };

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -190,6 +190,23 @@ suite('Element attribute bindings', function() {
     assert.strictEqual('x', element.id);
   });
 
+  test('Element.hidden?!', function() {
+    var element = testDiv.appendChild(document.createElement('div'));
+    var model = {visible:false};
+    element.bind('hidden?!', new PathObserver(model, 'visible'));
+
+    assert.isTrue(element.hasAttribute('hidden'));
+    assert.strictEqual('', element.getAttribute('hidden'));
+
+    model.visible = true;
+    Platform.performMicrotaskCheckpoint();
+    assert.isFalse(element.hasAttribute('hidden'));
+
+    model.visible = 'foo';
+    Platform.performMicrotaskCheckpoint();
+    assert.isFalse(element.hasAttribute('hidden'));
+  });
+
   test('Element.id - path unreachable', function() {
     var element = testDiv.appendChild(document.createElement('div'));
     var model = {};


### PR DESCRIPTION
There are some use cases where you need a negative conditional binding. If you have a model property "visible" and want to add an attribute "hidden" depending on this property, you don't want to add an additional property to the model just for the binding. The same applies for the "disabled" property of an select box where you have a model property "enabled".
