### PR TITLE
fix: add defensive checks against updates from duplicate bindings

### DIFF
--- a/src/NodeBind.js
+++ b/src/NodeBind.js
@@ -97,9 +97,11 @@
     node.data = sanitizeValue(value);
   }
 
-  function textBinding(node) {
+  function textBinding(node, binding) {
     return function(value) {
-      return updateText(node, value);
+      if (node.bindings.textContent === binding) {
+        updateText(node, value);
+      }
     };
   }
 
@@ -111,7 +113,7 @@
       return updateText(this, value);
 
     unbind(this, 'textContent');
-    updateText(this, value.open(textBinding(this)));
+    updateText(this, value.open(textBinding(this, value)));
     return this.bindings.textContent = value;
   }
 
@@ -127,9 +129,11 @@
     el.setAttribute(name, sanitizeValue(value));
   }
 
-  function attributeBinding(el, name, conditional) {
+  function attributeBinding(el, name, conditional, binding) {
     return function(value) {
-      updateAttribute(el, name, conditional, value);
+      if (el.bindings[name] === binding) {
+        updateAttribute(el, name, conditional, value);
+      }
     };
   }
 
@@ -145,7 +149,7 @@
 
     unbind(this, name);
     updateAttribute(this, name, conditional,
-        value.open(attributeBinding(this, name, conditional)));
+        value.open(attributeBinding(this, name, conditional, value)));
 
     return this.bindings[name] = value;
   };
@@ -197,9 +201,11 @@
     input[property] = (santizeFn || sanitizeValue)(value);
   }
 
-  function inputBinding(input, property, santizeFn) {
+  function inputBinding(input, property, santizeFn, binding) {
     return function(value) {
-      return updateInput(input, property, value, santizeFn);
+      if (input.bindings[property] === binding) {
+        updateInput(input, property, value, santizeFn);
+      }
     }
   }
 
@@ -292,7 +298,7 @@
     unbind(this, name);
     bindInputEvent(this, name, value, postEventFn);
     updateInput(this, name,
-                value.open(inputBinding(this, name, sanitizeFn)),
+                value.open(inputBinding(this, name, sanitizeFn, value)),
                 sanitizeFn);
 
     return this.bindings[name] = value;
@@ -310,7 +316,7 @@
     unbind(this, 'value');
     bindInputEvent(this, 'value', value);
     updateInput(this, 'value',
-                value.open(inputBinding(this, 'value', sanitizeValue)));
+                value.open(inputBinding(this, 'value', sanitizeValue, value)));
 
     return this.bindings.value = value;
   }
@@ -337,9 +343,11 @@
     }
   }
 
-  function optionBinding(option) {
+  function optionBinding(option, binding) {
     return function(value) {
-      updateOption(option, value);
+      if (option.bindings.value === binding) {
+        updateOption(option, value);
+      }
     }
   }
 
@@ -354,7 +362,7 @@
 
     unbind(this, 'value');
     bindInputEvent(this, 'value', value);
-    updateOption(this, value.open(optionBinding(this)));
+    updateOption(this, value.open(optionBinding(this, value)));
     return this.bindings.value = value;
   }
 
@@ -373,7 +381,7 @@
     unbind(this, name);
     bindInputEvent(this, name, value);
     updateInput(this, name,
-                value.open(inputBinding(this, name)));
+                value.open(inputBinding(this, name, undefined, value)));
     return this.bindings[name] = value;
   }
 })(this);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -116,6 +116,29 @@ suite('Text bindings', function() {
       done();
     });
   });
+
+
+  test('Duplicate binding', function(done) {
+    var text = document.createTextNode('hi');
+    var model1 = {a: 1};
+    var observer1 = new PathObserver(model1, 'a');
+    var model2 = {a: 2};
+    var observer2 = new PathObserver(model2, 'a');
+    text.bind('textContent', observer1);
+    assert.strictEqual('1', text.data);
+    text.bind('textContent', observer2);
+    assert.strictEqual('2', text.data);
+
+    model1.a = 11;
+    then(function() {
+      assert.strictEqual('1', text.data);
+      model2.a = 22;
+    }).then(function() {
+      assert.strictEqual('22', text.data);
+
+      done();
+    });
+  });
 });
 
 suite('Element attribute bindings', function() {
@@ -234,6 +257,29 @@ suite('Element attribute bindings', function() {
     var model = {};
     element.bind('id', new PathObserver(model, 'a'));
     assert.strictEqual(element.id, '');
+  });
+
+  test('Duplicate binding', function(done) {
+    var div = testDiv.appendChild(document.createElement('div'));
+    var model1 = {a: 1};
+    var observer1 = new PathObserver(model1, 'a');
+    var model2 = {a: 2};
+    var observer2 = new PathObserver(model2, 'a');
+    div.bind('foo', observer1);
+    assert.strictEqual('1', div.getAttribute('foo'));
+    div.bind('foo', observer2);
+    assert.strictEqual('2', div.getAttribute('foo'));
+    assert.strictEqual(/* closed */ 2, observer1.state_);
+
+    model1.a = 11;
+    then(function() {
+      assert.strictEqual('1', div.getAttribute('foo'));
+      model2.a = 22;
+    }).then(function() {
+      //assert.strictEqual('22', div.getAttribute('foo'));
+
+      done();
+    });
   });
 });
 


### PR DESCRIPTION
If a binding is closed, it should no logger be possible to update the binding value
via that binding.

---

This PR is not ready to be merged yet - some tests are failing and I can't figure out why that's the case. Some guidance would be appreciated.
