### PR TITLE
Fixed typo/bug in updateBindings()

### DIFF
--- a/src/NodeBind.js
+++ b/src/NodeBind.js
@@ -30,7 +30,7 @@
       bindings = node.bindings_ = {};
 
     if (bindings[name])
-      binding[name].close();
+      bindings[name].close();
 
     return bindings[name] = binding;
   }


### PR DESCRIPTION
I fixed a typo that prevents calling bind() if the same property already had one.
